### PR TITLE
Bigger Icons on Nav Bar

### DIFF
--- a/client/components/nav/nav.html
+++ b/client/components/nav/nav.html
@@ -3,12 +3,12 @@
     <div id="nav">
       <div class="ui secondary inverted menu">
         <a class="icon item" href="/">
-          <i class="ui home icon"></i>
+          <i class="ui home big icon"></i>
         </a>
 
         {{#if userIs 'admin'}}
           <a class="icon item" href="/admin">
-            <i class="ui settings icon"></i>
+            <i class="ui settings big icon"></i>
           </a>
         {{/if}}
 
@@ -43,7 +43,8 @@
 <template name="navMentor">
   {{#if userIs 'mentor'}}
     <a class="icon item" href="/mentor">
-      <i class="ui inbox icon"></i>
+        <p class="text">Mentors</p>
+
       {{#if openTickets}}
         <div class="ui tiny floating notification red label">
           {{ openTickets }}


### PR DESCRIPTION
Made icons bigger and changed confusing mentor icon to just the phrase "Mentors"
Only on the website version, because not sure how to work on the app version. 